### PR TITLE
Fix overflow in slides and add inline SVG image

### DIFF
--- a/custom-style.css
+++ b/custom-style.css
@@ -41,6 +41,7 @@
 /* Permite que las diapositivas scrollables usen todo el alto */
 .reveal .slides section.scrollable {
     justify-content: flex-start;
+    overflow-y: auto;
 }
 
 /* -- ESTILOS PARA TÍTULOS -- */

--- a/index.html
+++ b/index.html
@@ -287,7 +287,7 @@
             </section>
             
             <!-- El Viaje de los Datos -->
-            <section>
+            <section class="scrollable">
                 <h2>El Viaje de los Datos: Sabina Leonelli</h2>
                 <div class="two-column">
                     <div class="column">
@@ -313,7 +313,7 @@
             </section>
             
             <!-- Comprensión y Opacidad -->
-            <section>
+            <section class="scrollable">
                 <h2>Comprensión y Opacidad: Emily Sullivan</h2>
                 <div class="highlight-box">
                     <h3>Tesis Central</h3>
@@ -597,7 +597,7 @@
             </section>
             
             <!-- AlphaFold -->
-            <section>
+            <section class="scrollable">
                 <h2>AlphaFold: Revolución en Biología Estructural</h2>
                 <div class="two-column">
                     <div class="column">
@@ -613,7 +613,12 @@
                         </div>
                     </div>
                     <div class="column">
-                        <img src="data:image/svg+xml,%3Csvg width='400' height='300' xmlns='http://www.w3.org/2000/svg'%3E%3Crect width='400' height='300' fill='%23f0f0f0'/%3E%3Ctext x='50%25' y='50%25' text-anchor='middle' font-size='24' fill='%23666'%3EProtein Structure%3C/text%3E%3C/svg%3E" alt="Protein Structure Visualization">
+                        <svg width="400" height="300" xmlns="http://www.w3.org/2000/svg">
+                            <rect width="400" height="300" fill="#f0f0f0"></rect>
+                            <text x="50%" y="50%" text-anchor="middle" font-size="24" fill="#666">
+                                Protein Structure
+                            </text>
+                        </svg>
                     </div>
                 </div>
             </section>
@@ -653,7 +658,7 @@
             </section>
             
             <!-- Aceleración del Descubrimiento -->
-            <section>
+            <section class="scrollable">
                 <h2>Aceleración del Descubrimiento</h2>
                 <canvas id="discoveryChart" width="800" height="400"></canvas>
                 <p class="center" style="margin-top: 2em;">
@@ -948,7 +953,7 @@
             </section>
             
             <!-- Mensajes Clave -->
-            <section>
+            <section class="scrollable">
                 <h2>Mensajes Clave</h2>
                 <div class="center">
                     <div style="background: #e1f5fe; border: 3px solid #0366d6; border-radius: 12px; padding: 40px; display: inline-block; max-width: 80%;">


### PR DESCRIPTION
## Summary
- allow vertical scrolling on `scrollable` slides
- mark several content-heavy slides as `scrollable`
- replace AlphaFold placeholder image with inline SVG so it's always visible

## Testing
- `git status -b --porcelain`

------
https://chatgpt.com/codex/tasks/task_e_6867929b327c832a8b11dd6d2ab72edf