### PR TITLE
Fix slide layouts and add molecular SVG

### DIFF
--- a/img/molecule_structure.svg
+++ b/img/molecule_structure.svg
@@ -1,0 +1,20 @@
+<svg width="400" height="300" xmlns="http://www.w3.org/2000/svg">
+  <rect width="100%" height="100%" fill="#f0f0f0"/>
+  <!-- Simple molecular structure: hexagon with side chain -->
+  <g stroke="#0366d6" stroke-width="3" fill="none" stroke-linejoin="round">
+    <polygon points="200,60 250,90 250,150 200,180 150,150 150,90"/>
+    <line x1="250" y1="90" x2="290" y2="60"/>
+    <line x1="290" y1="60" x2="320" y2="80"/>
+  </g>
+  <g fill="#dc3545">
+    <circle cx="200" cy="60" r="6"/>
+    <circle cx="250" cy="90" r="6"/>
+    <circle cx="250" cy="150" r="6"/>
+    <circle cx="200" cy="180" r="6"/>
+    <circle cx="150" cy="150" r="6"/>
+    <circle cx="150" cy="90" r="6"/>
+    <circle cx="290" cy="60" r="6"/>
+    <circle cx="320" cy="80" r="6"/>
+  </g>
+  <text x="200" y="240" text-anchor="middle" font-size="24" fill="#666">Molecule</text>
+</svg>

--- a/index.html
+++ b/index.html
@@ -299,14 +299,14 @@
                         </ul>
                     </div>
                     <div class="column">
-                        <div style="text-align: center;">
-                            <div style="background: #f6f8fa; border-radius: 8px; padding: 20px; margin: 10px; display: inline-block; min-width: 220px;">Contexto Original</div>
-                            <div style="font-size: 2em;">↓</div>
-                            <div style="background: white; border: 2px solid #0366d6; border-radius: 8px; padding: 20px; margin: 10px; display: inline-block; min-width: 220px;">Descontextualización</div>
-                            <div style="font-size: 2em;">↓</div>
-                            <div style="background: #f6f8fa; border-radius: 8px; padding: 20px; margin: 10px; display: inline-block; min-width: 220px;">Viaje/Curación</div>
-                            <div style="font-size: 2em;">↓</div>
-                            <div style="background: white; border: 2px solid #0366d6; border-radius: 8px; padding: 20px; margin: 10px; display: inline-block; min-width: 220px;">Recontextualización</div>
+                        <div style="text-align: center; overflow-y: auto; max-height: 80vh;">
+                            <div style="background: #f6f8fa; border-radius: 8px; padding: 20px; margin: 5px; display: inline-block; min-width: 220px;">Contexto Original</div>
+                            <div style="font-size: 1.5em; margin: 5px 0;">↓</div>
+                            <div style="background: white; border: 2px solid #0366d6; border-radius: 8px; padding: 20px; margin: 5px; display: inline-block; min-width: 220px;">Descontextualización</div>
+                            <div style="font-size: 1.5em; margin: 5px 0;">↓</div>
+                            <div style="background: #f6f8fa; border-radius: 8px; padding: 20px; margin: 5px; display: inline-block; min-width: 220px;">Viaje/Curación</div>
+                            <div style="font-size: 1.5em; margin: 5px 0;">↓</div>
+                            <div style="background: white; border: 2px solid #0366d6; border-radius: 8px; padding: 20px; margin: 5px; display: inline-block; min-width: 220px;">Recontextualización</div>
                         </div>
                     </div>
                 </div>
@@ -324,7 +324,7 @@
                     $$\text{Riesgo Inductivo} \propto \text{Valores No-Epistémicos}$$
                 </div>
                 <div style="margin-top: 2em;">
-                    <h3>Implicaciones:</h3>
+                    <h3>Implicaciones</h3>
                     <ul>
                         <li>La opacidad tolerable depende del contexto de aplicación</li>
                         <li>Los valores éticos moldean los estándares de validación</li>
@@ -612,7 +612,7 @@
                             <span class='badge'>Nobel 2024</span><br>Reconocimiento máximo
                     </div>
                     <div class="column">
-                        <img src='img/protein_structure.svg' alt='Estructura proteica'>
+                        <img src='img/molecule_structure.svg' alt='Estructura molecular'>
                     </div>
                 </div>
             </section>
@@ -962,7 +962,7 @@
                         </p>
                     </div>
                 </div>
-                <p class='quote-footer'>
+                <p class='quote-footer' style="text-align: center;">
                     "El futuro de la ciencia no es humano o máquina,<br>
                     es humano <strong>con</strong> máquina"
                 </p>
@@ -1000,6 +1000,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/reveal.js/4.3.1/plugin/notes/notes.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/reveal.js/4.3.1/plugin/zoom/zoom.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/3.9.1/chart.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-datalabels@2"></script>
     
     <script>
         // Initialize Reveal.js
@@ -1019,6 +1020,7 @@
         // Chart configurations
         Chart.defaults.font.family = '-apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif';
         Chart.defaults.color = '#222';
+        Chart.register(ChartDataLabels);
         
         // ML Growth Chart
         const mlGrowthCtx = document.getElementById('mlGrowthChart');


### PR DESCRIPTION
## Summary
- shorten elements so "El Viaje de los Datos" fits on one slide
- remove colon in "Implicaciones" header
- display molecular structure image on AlphaFold slide
- load chartjs datalabel plugin for metrics slide
- center the key quote on the messages slide
- add new `molecule_structure.svg`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68679abf2c44832a86e41200edec32d3