### PR TITLE
Add improved AlphaFold visual

### DIFF
--- a/img/alphafold_molecule.svg
+++ b/img/alphafold_molecule.svg
@@ -1,0 +1,27 @@
+<svg width="400" height="300" xmlns="http://www.w3.org/2000/svg">
+  <rect width="100%" height="100%" fill="#f0f0f0"/>
+  <defs>
+    <linearGradient id="helixGrad" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#69c"/>
+      <stop offset="100%" stop-color="#0366d6"/>
+    </linearGradient>
+    <linearGradient id="bondGrad" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#dc3545"/>
+      <stop offset="100%" stop-color="#f28e8e"/>
+    </linearGradient>
+  </defs>
+  <!-- Helical backbone -->
+  <path d="M40 250 q60 -220 120 0 t120 0 t120 0" fill="none" stroke="url(#helixGrad)" stroke-width="8"/>
+  <!-- Connecting bonds -->
+  <path d="M40 250 L100 150 L160 250 L220 150 L280 250 L340 150" stroke="url(#bondGrad)" stroke-width="4" fill="none"/>
+  <!-- Atoms -->
+  <g fill="#ff7f50" stroke="#fff" stroke-width="2">
+    <circle cx="40" cy="250" r="10"/>
+    <circle cx="100" cy="150" r="10"/>
+    <circle cx="160" cy="250" r="10"/>
+    <circle cx="220" cy="150" r="10"/>
+    <circle cx="280" cy="250" r="10"/>
+    <circle cx="340" cy="150" r="10"/>
+  </g>
+  <text x="200" y="30" text-anchor="middle" font-size="24" fill="#666">AlphaFold</text>
+</svg>

--- a/index.html
+++ b/index.html
@@ -612,7 +612,7 @@
                             <span class='badge'>Nobel 2024</span><br>Reconocimiento máximo
                     </div>
                     <div class="column">
-                        <img src='img/clear_molecule.svg' alt='Estructura proteica modelada'>
+                        <img src='img/alphafold_molecule.svg' alt='Representaci\u00f3n molecular estilizada' style='max-height: 300px;'>
                     </div>
                 </div>
             </section>


### PR DESCRIPTION
## Summary
- add more detailed Alphafold molecular structure image
- display this new illustration in the AlphaFold slide

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6867aaf98bac832a9e186a1a0c0021ae