### PR TITLE
Fix logo overflow

### DIFF
--- a/index.html
+++ b/index.html
@@ -228,7 +228,7 @@
                 <h2>Aprendizaje automático, reconfiguración del conocimiento y el futuro de la investigación</h2>
                 <h3>Aníbal M. Astobiza</h3>
                 <h4>Universidad de Granada</h4>
-                <img src="UGR-MARCA-01-color.png" alt="Logo Universidad de Granada" style="margin-top: 1em; max-width: 250px;">
+                <img src="UGR-MARCA-01-color.png" alt="Logo Universidad de Granada" style="margin-top: 1em; max-width: 250px; max-height: 150px; height: auto;">
             </section>
             
             <!-- Resumen Ejecutivo -->


### PR DESCRIPTION
## Summary
- prevent the university logo from overlapping the first slide by capping its height

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6867bae48f20832aa1bd953784229d90