### PR TITLE
Add AI for Science summary slides

### DIFF
--- a/index.html
+++ b/index.html
@@ -367,6 +367,37 @@
                 </div>
             </section>
             
+
+            <!-- AI for Science Summary 1 -->
+            <section>
+                <h2>AI for Science: Agenda Emergente</h2>
+                <ul>
+                    <li>La complejidad actual exige nuevas formas de analizar sistemas naturales, tecnológicos y humanos.</li>
+                    <li>La IA permite extraer conocimiento a partir de grandes volúmenes de datos en múltiples escalas.</li>
+                    <li>Integrar modelos de ML con la experiencia de dominio es clave para avances científicos.</li>
+                </ul>
+            </section>
+
+            <!-- AI for Science Summary 2 -->
+            <section>
+                <h2>Tres Ejes de Investigación</h2>
+                <ul>
+                    <li><strong>Simulación híbrida:</strong> unir modelos mecanicistas y datos para representar sistemas complejos.</li>
+                    <li><strong>Causalidad:</strong> combinar inferencias de ML con leyes conocidas para revelar relaciones causa‑efecto.</li>
+                    <li><strong>Conocimiento estructurado:</strong> incorporar teoría y reglas explícitas en los modelos de IA.</li>
+                </ul>
+            </section>
+
+            <!-- AI for Science Summary 3 -->
+            <section>
+                <h2>Hoja de Ruta Propuesta</h2>
+                <ul>
+                    <li>Fomento de la colaboración continua entre especialistas en IA y ciencias aplicadas.</li>
+                    <li>Desarrollo de herramientas abiertas y buenas prácticas de ingeniería de software y datos.</li>
+                    <li>Impulso a la formación y a las comunidades que construyan un ecosistema de IA para la ciencia.</li>
+                </ul>
+            </section>
+
             <!-- Estado del Arte Section -->
             <section data-background="#f6f8fa" data-background-transition="slide">
                 <h1 style="text-align: center;">Estado del Arte</h1>


### PR DESCRIPTION
## Summary
- add three slides summarizing "AI for Science: An Emerging Agenda" after the theoretical convergence slide

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686f793b1430832aaba2ebc415ba9fa3